### PR TITLE
Rename types output dir

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "injecute",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "injecute",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "injecute",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Lightweight extendable typesafe dependency injection container",
   "repository": {
     "url": "git+https://github.com/Masyaka/injecute.git"

--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./lib/esm/types/index.d.ts",
+        "types": "./lib/esm/typedefs/index.d.ts",
         "default": "./lib/esm/index.mjs"
       },
       "require": {
-        "types": "./lib/cjs/types/index.d.ts",
+        "types": "./lib/cjs/typedefs/index.d.ts",
         "default": "./lib/cjs/index.js"
       }
     }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -6,6 +6,6 @@
     "module": "CommonJS",
     "moduleResolution": "Node",
     "outDir": "./lib/cjs",
-    "declarationDir": "./lib/cjs/types"
+    "declarationDir": "./lib/cjs/typedefs"
   }
 }

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -6,6 +6,6 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "outDir": "./lib/esm",
-    "declarationDir": "./lib/esm/types"
+    "declarationDir": "./lib/esm/typedefs"
   }
 }


### PR DESCRIPTION
Renamed the build directory where type declarations are output.
Renamed from types -> typedefs.
This is to avoid ambiguity with src/types.ts in the build output.
